### PR TITLE
Improve Google Photos client and MCP server reliability

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/eslintrc",
+  "root": true,
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "ignorePatterns": [
+    "dist/",
+    "node_modules/",
+    "test-mcp/"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}

--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -7,6 +7,9 @@ export interface TokenData {
   access_token: string;
   refresh_token: string;
   expiry_date: number;
+  userEmail?: string;
+  userId?: string;
+  retrievedAt?: number;
 }
 
 /**

--- a/src/types/mcp.d.ts
+++ b/src/types/mcp.d.ts
@@ -1,8 +1,8 @@
 declare module '@modelcontextprotocol/sdk' {
   export class McpServer {
     constructor(options: { name: string; version: string });
-    registerTool(name: string, options: any, handler: Function): void;
-    tool(name: string, schema: any, handler: Function, options?: any): void;
+    registerTool(name: string, options: any, handler: (...args: unknown[]) => unknown): void;
+    tool(name: string, schema: any, handler: (...args: unknown[]) => unknown, options?: any): void;
   }
   
   export function stdioTransport(server: McpServer): Promise<void>;

--- a/src/utils/googleUser.ts
+++ b/src/utils/googleUser.ts
@@ -1,0 +1,57 @@
+import logger from './logger.js';
+
+export interface GoogleIdTokenPayload {
+  email?: string;
+  sub?: string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  picture?: string;
+}
+
+function base64UrlDecode(input: string): string {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = normalized.length % 4;
+  const padded = padding ? normalized.padEnd(normalized.length + (4 - padding), '=') : normalized;
+  return Buffer.from(padded, 'base64').toString('utf8');
+}
+
+export function parseIdToken(idToken?: string | null): GoogleIdTokenPayload | null {
+  if (!idToken) {
+    return null;
+  }
+
+  try {
+    const segments = idToken.split('.');
+    if (segments.length < 2) {
+      return null;
+    }
+
+    const payloadSegment = segments[1];
+    const decoded = base64UrlDecode(payloadSegment);
+    const payload = JSON.parse(decoded) as GoogleIdTokenPayload;
+    return payload;
+  } catch (error) {
+    logger.warn(`Failed to parse Google ID token: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+export function resolveUserIdentity(payload: GoogleIdTokenPayload | null): {
+  userId: string;
+  email?: string;
+} {
+  if (!payload) {
+    return { userId: `user_${Date.now()}` };
+  }
+
+  if (payload.email) {
+    return { userId: payload.email, email: payload.email };
+  }
+
+  if (payload.sub) {
+    return { userId: payload.sub, email: payload.email };
+  }
+
+  return { userId: `user_${Date.now()}`, email: payload.email };
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -32,7 +32,7 @@ const logger = winston.createLogger({
 
 // Add a stream for using with express-winston
 logger.stream = {
-  // @ts-ignore
+  // @ts-expect-error - express-winston expects a stream-compatible interface
   write: (message: string) => {
     logger.info(message.trim());
   },


### PR DESCRIPTION
## Summary
- replace ad-hoc Google Photos API calls with a reusable client that normalises responses, enriches search filters, and adds text/location helpers for tools
- capture user identity details when saving tokens so auth-status responses can report who is connected
- tighten server tooling by wiring the new album/location helpers, exposing user info in auth_status, and adding an ESLint configuration for consistent linting

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c2f1ca50832abc7cd753247946c8