### PR TITLE
Improve text search token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ keywords:
   - includeLocation: boolean (optional, default: true)
   ```
 
+  Text queries are applied to filenames, descriptions, timestamps, and available location metadata. Tokens that do not appear in
+  any searchable field are ignored so that stop-words or date fragments do not filter out valid items, and if metadata filteri
+  ng would otherwise remove every item returned by Google Photos the original API response is preserved.
+
 - `search_photos_by_location`: Search for photos based on location
   ```
   Parameters:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "node --loader ts-node/esm src/index.ts",
     "stdio": "node dist/index.js --stdio",
     "lint": "eslint . --ext .ts",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "test": "node --loader ts-node/esm test/photos.test.ts"
   },
   "keywords": [
     "mcp",

--- a/src/api/photos.ts
+++ b/src/api/photos.ts
@@ -222,7 +222,7 @@ export function getPhotoClient(auth: OAuth2Client) {
   return createPhotosLibraryClient(auth);
 }
 
-function buildSearchTokens(query: string): string[] {
+export function buildSearchTokens(query: string): string[] {
   return query
     .toLowerCase()
     .split(/\s+/)
@@ -231,7 +231,7 @@ function buildSearchTokens(query: string): string[] {
     .filter((token) => token.length > 0);
 }
 
-function matchesSearchTokens(photo: PhotoItem, tokens: string[]): boolean {
+export function matchesSearchTokens(photo: PhotoItem, tokens: string[]): boolean {
   if (tokens.length === 0) {
     return true;
   }
@@ -253,7 +253,25 @@ function matchesSearchTokens(photo: PhotoItem, tokens: string[]): boolean {
     return false;
   }
 
-  return tokens.every((token) => haystack.some((value) => value.includes(token)));
+  const matchedTokens = tokens.filter((token) =>
+    haystack.some((value) => value.includes(token.toLowerCase())),
+  );
+
+  return matchedTokens.length > 0;
+}
+
+export function filterPhotosByTokens(photos: PhotoItem[], tokens: string[]): PhotoItem[] {
+  if (tokens.length === 0) {
+    return photos;
+  }
+
+  const filtered = photos.filter((photo) => matchesSearchTokens(photo, tokens));
+
+  if (filtered.length === 0) {
+    return photos;
+  }
+
+  return filtered;
 }
 
 function matchesLocationQuery(photo: PhotoItem, locationQuery: string): boolean {
@@ -595,7 +613,7 @@ export async function searchPhotosByText(
     );
 
     const tokens = buildSearchTokens(trimmedQuery);
-    const filteredPhotos = photos.filter((photo) => matchesSearchTokens(photo, tokens));
+    const filteredPhotos = filterPhotosByTokens(photos, tokens);
 
     return {
       photos: filteredPhotos,

--- a/test/photos.test.ts
+++ b/test/photos.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import {
+  buildSearchTokens,
+  filterPhotosByTokens,
+  matchesSearchTokens,
+  type PhotoItem,
+} from '../src/api/photos.js';
+
+function createPhoto(overrides: Partial<PhotoItem> = {}): PhotoItem {
+  return {
+    id: overrides.id ?? 'photo-1',
+    baseUrl: overrides.baseUrl ?? 'https://example.com/photo-1',
+    mimeType: overrides.mimeType ?? 'image/jpeg',
+    filename: overrides.filename ?? 'IMG_0001.JPG',
+    productUrl: overrides.productUrl ?? 'https://photos.google.com/lr/photo/1',
+    description: overrides.description,
+    mediaMetadata: overrides.mediaMetadata,
+    locationData: overrides.locationData,
+  };
+}
+
+function testMatchesSearchTokensIgnoresUnmatchedTokens() {
+  const tokens = buildSearchTokens('vacation 2023');
+  assert.deepEqual(tokens, ['vacation', '2023']);
+
+  const photo = createPhoto({ filename: 'Family Vacation in Hawaii.jpg' });
+
+  assert.equal(matchesSearchTokens(photo, tokens), true, 'Photo should match on vacation token');
+}
+
+function testFilterPhotosFallsBackWhenNoTokensMatch() {
+  const tokens = buildSearchTokens('family album');
+  const photos = [createPhoto({ id: 'photo-2', filename: 'IMG_9999.JPG' })];
+
+  const filtered = filterPhotosByTokens(photos, tokens);
+
+  assert.equal(filtered.length, 1, 'Filter should fall back to original results when nothing matches');
+  assert.equal(filtered[0].id, 'photo-2');
+}
+
+function testMatchesSearchTokensRequiresMatchedSubset() {
+  const tokens = buildSearchTokens('family reunion album');
+  const photo = createPhoto({ filename: 'Family Reunion Album Cover.jpg' });
+
+  assert.equal(matchesSearchTokens(photo, tokens), true, 'Photo should match when relevant tokens are present');
+}
+
+try {
+  testMatchesSearchTokensIgnoresUnmatchedTokens();
+  testFilterPhotosFallsBackWhenNoTokensMatch();
+  testMatchesSearchTokensRequiresMatchedSubset();
+  console.log('All photo search tests passed.');
+} catch (error) {
+  console.error('Test failure:', error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- relax the photo token matcher so unmatched search terms are ignored and add a shared helper for filtering
- ensure text searches fall back to the API results when metadata filtering would discard every photo
- document the behavior and add lightweight unit tests for queries such as "vacation 2023" and "family album"

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e5561c6888832a87527316af9ea7e3