### PR TITLE
Handle unmatched text search tokens gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ A Model Context Protocol (MCP) server for Google Photos integration, allowing Cl
 - Enhanced error handling and 2025 API compatibility warnings
 - Works with Claude Desktop, Cursor IDE, and other MCP-compatible clients through the MCP standard
 
+### Text search behavior
+
+- Search queries are tokenized on whitespace/`:` and compared against photo filenames, descriptions, timestamps, and any cached
+  location metadata.
+- Tokens that do not appear in any searchable fields are ignored so that queries like `vacation 2023` still surface "vacation"
+  matches even when the year is missing from the metadata.
+- When none of the tokens match, the server falls back to the Google Photos API response instead of returning an empty result
+  set, preserving the original ordering for broad or unmatched queries.
+
 ## Prerequisites
 
 - Node.js 18 or newer

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "node --loader ts-node/esm src/index.ts",
     "stdio": "node dist/index.js --stdio",
     "lint": "eslint . --ext .ts",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "test": "node --loader ts-node/esm --test src/api/__tests__/photos.test.ts"
   },
   "keywords": [
     "mcp",

--- a/src/api/__tests__/photos.test.ts
+++ b/src/api/__tests__/photos.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { filterPhotosByTokens } from '../photos.js';
+import type { PhotoItem } from '../photos.js';
+
+function createPhoto(overrides: Partial<PhotoItem>): PhotoItem {
+  return {
+    id: overrides.id ?? 'photo-id',
+    baseUrl: overrides.baseUrl ?? 'https://example.com/photo.jpg',
+    mimeType: overrides.mimeType ?? 'image/jpeg',
+    filename: overrides.filename ?? 'photo.jpg',
+    description: overrides.description,
+    productUrl: overrides.productUrl ?? 'https://photos.google.com',
+    mediaMetadata:
+      overrides.mediaMetadata ??
+      ({
+        creationTime: '2020-01-01T00:00:00Z',
+        width: '1000',
+        height: '800',
+      } satisfies PhotoItem['mediaMetadata']),
+    locationData: overrides.locationData,
+  };
+}
+
+test('retains photos when at least one token matches metadata', () => {
+  const photos = [
+    createPhoto({
+      id: 'vacation-photo',
+      filename: 'Summer Vacation.jpg',
+      description: 'Trip to the beach with friends',
+    }),
+    createPhoto({
+      id: 'family-photo',
+      filename: 'Family reunion.png',
+      description: 'Family reunion 2022',
+      mediaMetadata: {
+        creationTime: '2022-01-01T00:00:00Z',
+        width: '1000',
+        height: '800',
+      },
+    }),
+  ];
+
+  const filtered = filterPhotosByTokens(photos, ['vacation', '2023']);
+
+  assert.deepEqual(
+    filtered.map((photo) => photo.id),
+    ['vacation-photo'],
+  );
+});
+
+test('retains photos for multi-word queries present in metadata', () => {
+  const photos = [
+    createPhoto({
+      id: 'family-album-cover',
+      description: 'Scanning our family album cover for the project',
+    }),
+    createPhoto({
+      id: 'random-shot',
+      description: 'City skyline at night',
+    }),
+  ];
+
+  const filtered = filterPhotosByTokens(photos, ['family', 'album']);
+
+  assert.deepEqual(
+    filtered.map((photo) => photo.id),
+    ['family-album-cover'],
+  );
+});
+
+test('falls back to the original list when no tokens match', () => {
+  const photos = [
+    createPhoto({ id: 'first-photo', description: 'A walk in the park' }),
+    createPhoto({ id: 'second-photo', description: 'Evening skyline' }),
+  ];
+
+  const filtered = filterPhotosByTokens(photos, ['unmatched']);
+
+  assert.strictEqual(filtered, photos);
+});

--- a/src/api/photos.ts
+++ b/src/api/photos.ts
@@ -253,7 +253,32 @@ function matchesSearchTokens(photo: PhotoItem, tokens: string[]): boolean {
     return false;
   }
 
-  return tokens.every((token) => haystack.some((value) => value.includes(token)));
+  const matchedTokens = new Set<string>();
+
+  for (const token of tokens) {
+    for (const value of haystack) {
+      if (value.includes(token)) {
+        matchedTokens.add(token);
+        break;
+      }
+    }
+  }
+
+  return matchedTokens.size > 0;
+}
+
+export function filterPhotosByTokens(photos: PhotoItem[], tokens: string[]): PhotoItem[] {
+  if (tokens.length === 0) {
+    return photos;
+  }
+
+  const filtered = photos.filter((photo) => matchesSearchTokens(photo, tokens));
+
+  if (filtered.length === 0) {
+    return photos;
+  }
+
+  return filtered;
 }
 
 function matchesLocationQuery(photo: PhotoItem, locationQuery: string): boolean {
@@ -595,7 +620,7 @@ export async function searchPhotosByText(
     );
 
     const tokens = buildSearchTokens(trimmedQuery);
-    const filteredPhotos = photos.filter((photo) => matchesSearchTokens(photo, tokens));
+    const filteredPhotos = filterPhotosByTokens(photos, tokens);
 
     return {
       photos: filteredPhotos,


### PR DESCRIPTION
## Summary
- ignore unmatched query tokens when filtering photos and fall back to the API results when filtering would remove everything
- expose a reusable helper for token filtering and add targeted tests for queries like "vacation 2023" and "family album"
- document how text token matching now works for future contributors and add an npm test script

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5563c3208832a8e99c5dbbf9f714d