### PR TITLE
fix: use query param for picker mediaItems list endpoint

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -334,10 +334,10 @@ export function getPickerClient(auth: OAuth2Client) {
       ) => {
         try {
           const headers = await getAuthorizedHeaders(auth);
-          const response = await pickerApi.get(
-            `/sessions/${sessionId}/mediaItems`,
-            { params, headers },
-          );
+          const response = await pickerApi.get(`/mediaItems`, {
+            params: { sessionId, ...params },
+            headers,
+          });
           return { data: response.data };
         } catch (error) {
           throw toError(error, "picker.sessions.listMediaItems");


### PR DESCRIPTION
 Fix the Picker API `listMediaItems` call to use the correct endpoint shape. The Google Photos Picker API exposes media items at `GET /v1/mediaItems?sessionId={id}`, not as a sub-resource of the session. The previous path-based form returned 404s and made `poll_picker_session` unable to retrieve picked items.
