### PR TITLE
Fix dotenv stdout banner breaking STDIO transport

### DIFF
--- a/src/dxt-server.ts
+++ b/src/dxt-server.ts
@@ -10,7 +10,7 @@ import dotenv from "dotenv";
 import logger from "./utils/logger.js";
 import { GooglePhotosMCPCore } from "./mcp/core.js";
 
-dotenv.config();
+dotenv.config({ quiet: true });
 
 const DXT_TIMEOUT = 30000; // 30 seconds timeout for DXT operations
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,7 +3,9 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 // Load environment variables
-dotenv.config({ override: true });
+// quiet: true suppresses dotenv's stdout banner, which would otherwise corrupt
+// the JSON-RPC stream in STDIO mode (see index.ts for the same treatment).
+dotenv.config({ override: true, quiet: true });
 
 // Derive project root from this file's location (src/utils/config.ts or dist/utils/config.js -> ../../)
 // This is stable regardless of process.cwd(), which varies depending on how the MCP client launches the server.


### PR DESCRIPTION
## Problem

Running the server in STDIO mode (e.g. Claude Desktop) fails to connect: the client immediately closes the connection at startup with a JSON parse error:

```
[error] Unexpected token 'd', "[dotenv@17."... is not valid JSON
Server transport closed unexpectedly
```

## Root cause

dotenv v17 prints an `[dotenv@17.x] injecting env (N) from .env` banner to **stdout** on `config()`. In STDIO mode stdout is the JSON-RPC channel, so the banner corrupts the very first bytes the client reads, it fails to parse them, and the connection dies before `initialize` completes.

`src/index.ts` already guards against this with `dotenv.config({ quiet: true })`, but two other call sites do not:

- `src/utils/config.ts` — `dotenv.config({ override: true })` — imported on **every** startup, including STDIO
- `src/dxt-server.ts` — `dotenv.config()`

Because `utils/config.ts` runs on import, the banner reaches stdout even when launched via the STDIO entry point.

## Fix

Add `quiet: true` to both remaining `dotenv.config()` calls, consistent with `index.ts` and the repo's own rule (CLAUDE.md) against stdout writes in STDIO mode. Two-line change, no behaviour change beyond suppressing the banner.

## Verification

- `npm run build`, `npm run lint`, `npm test` (245 tests) all pass
- Confirmed a raw `initialize` handshake over `node dist/index.js --stdio` now returns clean JSON-RPC on stdout with no banner
- Server connects successfully in Claude Desktop and live Picker + Library calls work end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)